### PR TITLE
Refactored to support latest Firefox

### DIFF
--- a/lib/extended-page-mod.js
+++ b/lib/extended-page-mod.js
@@ -1,5 +1,3 @@
-/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
-/* vim:set ts=2 sw=2 sts=2 et: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -9,14 +7,11 @@ module.metadata = {
   "stability": "stable"
 };
 
-
 //const observers = require('sdk/deprecated/observer-service');
 var events = require("sdk/system/events");
 const unload = require('sdk/system/unload');
-const { Loader, validationAttributes } = require('sdk/content/loader');
+const { validationAttributes } = require('sdk/content/loader');
 const { Worker } = require('sdk/content/worker');
-const { EventEmitter } = require('sdk/deprecated/events');
-const { List } = require('sdk/deprecated/list');
 const { MatchPattern } = require('sdk/util/match-pattern');
 const { validateOptions : validate } = require('sdk/deprecated/api-utils');
 const { Cc, Ci } = require('chrome');
@@ -28,7 +23,10 @@ const { getTabs, getTabContentWindow, getTabForContentWindow,
   getURI: getTabURI } = require('sdk/tabs/utils');
 const { has, hasAny } = require('sdk/util/array');
 const { ignoreWindow } = require('sdk/private-browsing/utils');
-
+const { emit, count } = require('sdk/event/core');
+const { EventTarget } = require('sdk/event/target');
+const { Class } = require('sdk/core/heritage');
+const { Disposable } = require('sdk/core/disposable');
 const styleSheetService = Cc["@mozilla.org/content/style-sheet-service;1"].
   getService(Ci.nsIStyleSheetService);
 
@@ -51,60 +49,99 @@ const validStyleOptions = {
   })
 };
 
-// rules registry
-const RULES = {};
+//const selfEmit = (event, data) => emit(this, event, data);
+const selfEmit = function (event, data) {
+  emit(this, event, data);
+};
 
-// ANTI RULES
-const EXCLUDE_RULES = {}
+//@NOTE: Class should be replaced with proper es6 class Rules extends Map
+/**
+ * Maintains a mapping of URL to MatchPattern
+ * @constructor
+ */
+const Rules = Class({
+  implements: [EventTarget],
+  initialize() {
+    //We can't inherit from Map yet, so we're exposing what we need
+    this._map = new Map();
+  },
+  add(rules) {
+    [].concat(rules).forEach(rule => {
+      if (this._map.has(rule)) return;
 
-const Rules = EventEmitter.resolve({ toString: null }).compose(List, {
-    add: function() Array.slice(arguments).forEach(function onAdd(rule) {
-      if (this._has(rule))
-        return;
-      // registering rule to the rules registry
-      if (!(rule in RULES))
-        RULES[rule] = new MatchPattern(rule);
-      this._add(rule);
-      this._emit('add', rule);
-    }.bind(this)),
-  remove: function() Array.slice(arguments).forEach(function onRemove(rule) {
-  if (!this._has(rule))
-    return;
-  this._remove(rule);
-  this._emit('remove', rule);
-}.bind(this)),
+      this._map.set(rule, new MatchPattern(rule));
+      this.emit('add', rule);
+    });
+  },
+  remove(rules) {
+    [].concat(rules).forEach(rule => {
+      this._map.delete(rule);
+      this.emit('remove', rule);
+    });
+  },
+  emit: selfEmit,
+  //@NOTE: Until we can properly extend Map
+  values() {
+    return this._map.values();
+  },
+  keys() {
+    return this._map.keys();
+  },
+  entries() {
+    return this._map.entries();
+  },
+  forEach(fn) {
+    this._map.forEach(fn);
+  },
+  //@NOTE: some is not supported by Map, so we're faking it
+  some(fn) {
+    for (let [key, value] of this._map.entries()) {
+      if (fn(value, key)) return true;
+    }
+
+    return false;
+  }
 });
+
+const contentScripts = ['contentScript', 'contentScriptFile', 'contentScriptOptions', 'contentScriptWhen'];
 
 /**
  * ExtendedPageMod constructor (exported below).
  * @constructor
+ * @param {object} options - Configuration options found in site-configuration.js
+ * @param {string} options.contentStyle -
+ * @param {string[]} options.contentStyleFile - CSS files added to the page
+ * @param {string} options.contentScript -
+ * @param {string[]} options.contentScriptFile - Script files added to the page
+ * @param {string} options.contentScriptOptions -  Data is added to a set of constants that are available on the content script
+ * @param {string} options.contentScriptWhen - Document state to start worker, either 'start', 'ready', or end
+ * @param {string[]} options.include - URL patterns to match against for including the script
+ * @param {string[]} [options.exclude] - URL patterns to match against for excluding the script
+ * @param {function} options.onAttach - Handles when the worker is attached
+ * @param {function} options.onError - Possibly unused
+ * @param {string[]} options.attachTo - Places to create the worker. 'top', 'frame', 'existing', or some combination are valid as long as 'top' or 'frame' is included
  */
-const ExtendedPageMod = Loader.compose(EventEmitter, {
-  on: EventEmitter.required,
-  _listeners: EventEmitter.required,
+const ExtendedPageMod = Class({
+  extends: EventTarget,
+  implements: [Disposable],
   attachTo: [],
-  contentScript: Loader.required,
-  contentScriptFile: Loader.required,
-  contentScriptWhen: Loader.required,
-  contentScriptOptions: Loader.required,
   excludeURLs: null,
   include: null,
-  constructor: function ExtendedPageMod(options) {
+  setup(options) {
     this._onContent = this._onContent.bind(this);
     options = options || {};
 
+    //@TODO: Determine whether validating all validationAttributes is the way to go,
+    //or if this is even necessary
     let { contentStyle, contentStyleFile } = validate(options, validStyleOptions);
 
-    if ('contentScript' in options)
-      this.contentScript = options.contentScript;
-    if ('contentScriptFile' in options)
-      this.contentScriptFile = options.contentScriptFile;
-    if ('contentScriptOptions' in options)
-      this.contentScriptOptions = options.contentScriptOptions;
-    if ('contentScriptWhen' in options)
-      this.contentScriptWhen = options.contentScriptWhen;
+    contentScripts.forEach(script => {
+      if (script in options) this[script] = options[script];
+    });
+
     if ('onAttach' in options)
       this.on('attach', options.onAttach);
+    //@TODO: Determine whether we are actually catching errors through the handler at all, when nowhere emits it
     if ('onError' in options)
       this.on('error', options.onError);
     if ('attachTo' in options) {
@@ -119,7 +156,8 @@ const ExtendedPageMod = Loader.compose(EventEmitter, {
       let isValidAttachToItem = function isValidAttachToItem(item) {
         return typeof item === 'string' &&
           VALID_ATTACHTO_OPTIONS.indexOf(item) !== -1;
-      }
+      };
+
       if (!this.attachTo.every(isValidAttachToItem))
         throw new Error('The `attachTo` option valid accept only following ' +
           'values: '+ VALID_ATTACHTO_OPTIONS.join(', '));
@@ -131,27 +169,14 @@ const ExtendedPageMod = Loader.compose(EventEmitter, {
       this.attachTo = ["top", "frame"];
     }
 
-    let include = options.include;
-    let exclude = options.exclude || [];
-    let rules = this.include = Rules();
+    //let exclude =  [].concat(options.exclude);
+    let rules = this.include = new Rules();
     rules.on('add', this._onRuleAdd = this._onRuleAdd.bind(this));
     rules.on('remove', this._onRuleRemove = this._onRuleRemove.bind(this));
+    rules.add(options.include);
 
-    // Build exclusion array
-    if(Array.isArray(exclude)) {
-      this.excludeURLs = [];
-      for(let i = 0; i < exclude.length; i++) {
-        this.excludeURLs.push(new MatchPattern(exclude[i]));
-      }
-    } else {
-      this.excludeURLs = [new MatchPattern(exclude)];
-    }
-
-    if (Array.isArray(include)) {
-      rules.add.apply(null, include);
-    } else {
-      rules.add(include);
-    }
+    let exclude = this.exclude = new Rules();
+    options.exclude && exclude.add(options.exclude);
 
     let styleRules = "";
 
@@ -172,67 +197,58 @@ const ExtendedPageMod = Loader.compose(EventEmitter, {
     }
 
     this.on('error', this._onUncaughtError = this._onUncaughtError.bind(this));
-    pageModManager.add(this._public);
+    pageModManager.add(this);
 
     this._loadingWindows = [];
 
     // `_applyOnExistingDocuments` has to be called after `pageModManager.add()`
     // otherwise its calls to `_onContent` method won't do anything.
-    if ('attachTo' in options && has(options.attachTo, 'existing'))
+    if ('attachTo' in options && has(options.attachTo, 'existing')) {
       this._applyOnExistingDocuments();
+    }
   },
 
-  destroy: function destroy() {
-
+  dispose() {
     this._unregisterStyleSheet();
 
-    this.include.removeListener('add', this._onRuleUpdate);
-    this.include.removeListener('remove', this._onRuleUpdate);
+    this.include.off('add', this._onRuleUpdate);
+    this.include.off('remove', this._onRuleUpdate);
 
-    for each (let rule in this.include)
-    this.include.remove(rule);
-    pageModManager.remove(this._public);
+    //We need the Manager to remove all event handlers for this instance's urls
+    this.include.remove([...this.include.keys()]); 
+
+    pageModManager.remove(this);
     this._loadingWindows = [];
-
   },
 
   _loadingWindows: [],
 
-  _applyOnExistingDocuments: function _applyOnExistingDocuments() {
-    let mod = this;
-    // Returns true if the tab match one rule
-    function isMatchingURI(uri) {
-      // Use Array.some as `include` isn't a native array
-      return Array.some(mod.include, function (rule) {
-        return RULES[rule].test(uri);
-      });
-    }
-    let tabs = getAllTabs().filter(function (tab) {
-      return isMatchingURI(getTabURI(tab));
-    });
-
-    tabs.forEach(function (tab) {
-      // Fake a newly created document
-      let window = getTabContentWindow(tab);
-      if (has(mod.attachTo, "top"))
-        mod._onContent(window);
-      if (has(mod.attachTo, "frame"))
-        getFrames(window).forEach(mod._onContent);
-    });
+  _isMatchingURI(uri) {
+    return [...this.include.values()].some(pattern => pattern.test(uri));
   },
 
-  _onContent: function _onContent(window) {
+  _applyOnExistingDocuments() {
+    getAllTabs()
+      .filter(tab => this._isMatchingURI(getTabURI(tab)))
+      .forEach(tab => {
+      // Fake a newly created document
+        let window = getTabContentWindow(tab);
+        if (has(this.attachTo, "top"))
+          this._onContent(window);
+        if (has(this.attachTo, "frame"))
+          getFrames(window).forEach(this._onContent);
+      });
+  },
+
+  _onContent(window) {
     // If page is to be ignored
     var url = window.document.URL;
-    for each (let excludeURL in this.excludeURLs) {
-      if(excludeURL.test(url)) {
-        return;
-      }
+    for (let exclude of this.exclude.values()) {
+      if(exclude.test(url)) return;
     }
 
     // not registered yet
-    if (!pageModManager.has(this))
-      return;
+    if (!pageModManager.has(this)) return;
 
     let isTopDocument = window.top === window;
     // Is a top level document and `top` is not set, ignore
@@ -264,7 +280,7 @@ const ExtendedPageMod = Loader.compose(EventEmitter, {
       self._createWorker(window);
     }, true);
   },
-  _createWorker: function _createWorker(window) {
+  _createWorker(window) {
     let worker = Worker({
       window: window,
       contentScript: this.contentScript,
@@ -272,58 +288,50 @@ const ExtendedPageMod = Loader.compose(EventEmitter, {
       contentScriptOptions: this.contentScriptOptions,
       onError: this._onUncaughtError
     });
-    this._emit('attach', worker);
-    let self = this;
-    worker.once('detach', function detach() {
-      worker.destroy();
-    });
+    emit(this, 'attach', worker);
+    worker.once('detach', worker.destroy);
   },
-  _onRuleAdd: function _onRuleAdd(url) {
+  _onRuleAdd(url) {
     pageModManager.on(url, this._onContent);
   },
-  _onRuleRemove: function _onRuleRemove(url) {
+  _onRuleRemove(url) {
     pageModManager.off(url, this._onContent);
   },
-  _onUncaughtError: function _onUncaughtError(e) {
-    if (this._listeners('error').length == 1)
-      console.exception(e);
+  _onUncaughtError(e) {
+    //@TODO: Determine if we actually only want console.exception when we lack an event handler
+    if (count(this, 'error') == 1) console.exception(e);
   },
-  _onRuleUpdate: function _onRuleUpdate(){
+  _onRuleUpdate(){
     this._registerStyleSheet();
   },
 
-  _registerStyleSheet : function _registerStyleSheet() {
-    let rules = this.include;
+  _registerStyleSheet() {
     let styleRules = this._styleRules;
-
-    let documentRules = [];
 
     this._unregisterStyleSheet();
 
-    for each (let rule in rules) {
-      let pattern = RULES[rule];
-
-      if (!pattern)
-        continue;
-
+    let documentRules = [...this.include.values()].reduce(function (acc, pattern) {
       if (pattern.regexp)
-        documentRules.push("regexp(\"" + pattern.regexp.source + "\")");
+        acc.push("regexp(\"" + pattern.regexp.source + "\")");
       else if (pattern.exactURL)
-        documentRules.push("url(" + pattern.exactURL + ")");
+        acc.push("url(" + pattern.exactURL + ")");
       else if (pattern.domain)
-        documentRules.push("domain(" + pattern.domain + ")");
+        acc.push("domain(" + pattern.domain + ")");
       else if (pattern.urlPrefix)
-        documentRules.push("url-prefix(" + pattern.urlPrefix + ")");
+        acc.push("url-prefix(" + pattern.urlPrefix + ")");
       else if (pattern.anyWebPage)
-        documentRules.push("regexp(\"^(https?|ftp)://.*?\")");
-    }
+        acc.push("regexp(\"^(https?|ftp)://.*?\")");
+
+      return acc;
+    }, []);
 
     let uri = "data:text/css;charset=utf-8,";
-    if (documentRules.length > 0)
-      uri += encodeURIComponent("@-moz-document " +
-        documentRules.join(",") + " {" + styleRules + "}");
-    else
+    if (documentRules.length > 0) {
+      uri += encodeURIComponent(`@-moz-document ${documentRules} {${styleRules}}`);
+    }
+    else {
       uri += encodeURIComponent(styleRules);
+    }
 
     this._registeredStyleURI = io.newURI(uri, null, null);
 
@@ -333,92 +341,90 @@ const ExtendedPageMod = Loader.compose(EventEmitter, {
     );
   },
 
-  _unregisterStyleSheet : function () {
+  _unregisterStyleSheet() {
     let uri = this._registeredStyleURI;
 
-    if (uri  && styleSheetService.sheetRegistered(uri, USER_SHEET))
+    if (uri && styleSheetService.sheetRegistered(uri, USER_SHEET)) {
       styleSheetService.unregisterSheet(uri, USER_SHEET);
+    }
 
     this._registeredStyleURI = null;
   }
 });
-exports.ExtendedPageMod = function(options) ExtendedPageMod(options)
+exports.ExtendedPageMod = options => ExtendedPageMod(options);
 exports.ExtendedPageMod.prototype = ExtendedPageMod.prototype;
 
-const Registry = EventEmitter.compose({
-  _registry: null,
-  _constructor: null,
-  constructor: function Registry(constructor) {
-    this._registry = [];
-    this._constructor = constructor;
-    this.on('error', this._onError = this._onError.bind(this));
-    unload.ensure(this, "_destructor");
+/**
+ * ExtendedPageModManager manages all registed instances of ExtendedPageMod
+ * It does most of this work on `document-element-inserted`
+ * and then finding the instance associated with a window 
+ */
+const ExtendedPageModManager = Class({
+  extends: EventTarget,
+  implements: [Disposable],
+  _off: EventTarget.prototype.off,
+  _onError(e) {
+    if (!count(this, 'error')) console.error(e);
   },
-  _destructor: function _destructor() {
-    let _registry = this._registry.slice(0);
-    for (let instance of _registry)
-      this._emit('remove', instance);
-    this._registry.splice(0);
-  },
-  _onError: function _onError(e) {
-    if (!this._listeners('error').length)
-      console.error(e);
-  },
-  has: function has(instance) {
+  has(instance) {
     let _registry = this._registry;
     return (
-      (0 <= _registry.indexOf(instance)) ||
-      (instance && instance._public && 0 <= _registry.indexOf(instance._public))
+      (0 <= _registry.indexOf(instance)) /*||
+        (instance && instance._public && 0 <= _registry.indexOf(instance._public))//*/
     );
   },
-  add: function add(instance) {
+  add(instance) {
     let { _constructor, _registry } = this; 
-    if (!(instance instanceof _constructor))
+    if (!(instance instanceof _constructor)) {
       instance = new _constructor(instance);
-    if (0 > _registry.indexOf(instance)) {
+    }
+
+    if (0 >_registry.indexOf(instance)) {
       _registry.push(instance);
-      this._emit('add', instance);
+      this.emit('add', instance);
     }
     return instance;
   },
-  remove: function remove(instance) {
+  remove(instance) {
     let _registry = this._registry;
-    let index = _registry.indexOf(instance)
+    let index = _registry.indexOf(instance);
     if (0 <= index) {
-      this._emit('remove', instance);
+      this.emit('remove', instance);
       _registry.splice(index, 1);
     }
-  }
-});
+  },
+  emit: selfEmit,
+  setup() {
+    this._registry = [];
+    this._constructor = ExtendedPageMod;
+    this.on('error', this._onError = this._onError.bind(this));
 
-const ExtendedPageModManager = Registry.resolve({
-  constructor: '_init',
-  _destructor: '_registryDestructor'
-}).compose({
-  constructor: function ExtendedPageModRegistry(constructor) {
-    this._init(ExtendedPageMod);
     events.on(
       'document-element-inserted',
       this._onContentWindow = this._onContentWindow.bind(this),
       true
     );
   },
-  _destructor: function _destructor() {
+  dispose() {
     events.off('document-element-inserted', this._onContentWindow);
-    this._removeAllListeners();
-    for (let rule in RULES) {
-      delete RULES[rule];
-    }
+    this._off();
 
     // We need to do some cleaning er ExtendedPageMods, like unregistering any
     // `contentStyle*`
-    this._registry.forEach(function(pageMod) {
-      pageMod.destroy();
-    });
+    this._registry.forEach(pageMod => pageMod.destroy());
 
-    this._registryDestructor();
+    //@TODO: Determine why we need a slice, when we aren't mutating anything?
+    let _registry = this._registry.slice(0);
+    //@TODO: Determine if there is any reason for this at all
+    for (let instance of _registry) {
+      this.emit('remove', instance);
+    }
+
+    //_registry.forEach(instance => this.emit('remove', instance));
+
+    this._registry.splice(0); 
   },
-  _onContentWindow: function _onContentWindow(event) {
+  _onContentWindow(event) {
     let document = event.subject;
     let window = document.ownerGlobal;
     // XML documents don't have windows, and we don't yet support them.
@@ -436,23 +442,29 @@ const ExtendedPageModManager = Registry.resolve({
       return;
     }
 
-    for (let rule in RULES)
-      if (RULES[rule].test(document.URL)) {
-        // If the content script is already injected we want to just exit
-        if (window.__contentScriptInjected) {
-          return;
-        }
+    if (window.__contentScriptInjected) return;
+
+    //@TODO:Determine if we need to iterate every instance & test or
+    //is the first one enough
+    this._registry.some(instance => {
+      return instance.include.some((pattern, url) => {
+        if (!pattern.test(document.URL)) return false;
+
         window.__contentScriptInjected = true;
-        this._emit(rule, window);
-      }
+        this.emit(url, window);
+
+        return true;
+      });
+    });
   },
-  off: function off(topic, listener) {
-    this.removeListener(topic, listener);
-    if (!this._listeners(topic).length)
-      delete RULES[topic];
+  off(topic, listener) {
+    this._off(topic, listener);
+    if (!count(this, topic)) {
+      this._registry.forEach(instance => instance.include.remove(topic));
+    }
   }
 });
-const pageModManager = ExtendedPageModManager();
+const pageModManager = new ExtendedPageModManager();
 
 // Returns all tabs on all currently opened windows
 function getAllTabs() {
@@ -465,4 +477,3 @@ function getAllTabs() {
   }
   return tabs;
 }
-


### PR DESCRIPTION
All deprecated functionality that had been removed was replaced with the most current ways of doing things, aside from functionality deprecated, but not relocated yet.

@nzack @JasonGhent and not sure who else might all want to look at this. This is a giant pull party with floaties provided for those that need them.