### PR TITLE
WS-1996 Fixes/Enhancements

### DIFF
--- a/lib/extended-page-mod.js
+++ b/lib/extended-page-mod.js
@@ -7,7 +7,6 @@ module.metadata = {
   "stability": "stable"
 };
 
-//const observers = require('sdk/deprecated/observer-service');
 var events = require("sdk/system/events");
 const unload = require('sdk/system/unload');
 const { validationAttributes } = require('sdk/content/loader');

--- a/lib/extended-page-mod.js
+++ b/lib/extended-page-mod.js
@@ -283,14 +283,17 @@ const ExtendedPageMod = Class({
     }, true);
   },
   _createWorker(window) {
+    let self = this;
     let worker = Worker({
       window: window,
       contentScript: this.contentScript,
       contentScriptFile: this.contentScriptFile,
       contentScriptOptions: this.contentScriptOptions,
-      onError: this._onUncaughtError
+      onError: this._onUncaughtError,
+      onAttach() {
+        emit(self, 'attach', this);
+      }
     });
-    emit(this, 'attach', worker);
     worker.once('detach', worker.destroy);
   },
   _onRuleAdd(url) {

--- a/lib/extended-page-mod.js
+++ b/lib/extended-page-mod.js
@@ -16,8 +16,7 @@ const { validateOptions : validate } = require('sdk/deprecated/api-utils');
 const { Cc, Ci } = require('chrome');
 const { merge } = require('sdk/util/object');
 const { readURISync } = require('sdk/net/url');
-const { windowIterator } = require('sdk/deprecated/window-utils');
-const { isBrowser, getFrames } = require('sdk/window/utils');
+const { isBrowser, getFrames, windows, isDocumentLoaded } = require('sdk/window/utils');
 const { getTabs, getTabContentWindow, getTabForContentWindow,
   getURI: getTabURI } = require('sdk/tabs/utils');
 const { has, hasAny } = require('sdk/util/array');
@@ -473,10 +472,10 @@ const pageModManager = new ExtendedPageModManager();
 function getAllTabs() {
   let tabs = [];
   // Iterate over all chrome windows
-  for (let window in windowIterator()) {
-    if (!isBrowser(window))
-      continue;
-    tabs = tabs.concat(getTabs(window));
-  }
-  return tabs;
+  return windows().reduce((acc, window) => {
+    //@NOTE: windowIterator did this https://github.com/mozilla/addon-sdk/blob/firefox40/lib/sdk/deprecated/window-utils.js#L32
+    //It pretty much just wrapped windows().filter(isDocumentLoaded)
+    if (isDocumentLoaded(window) && isBrowser(window)) return acc.concat(getTabs(window));
+    else return acc;
+  }, []);
 }

--- a/lib/extended-page-mod.js
+++ b/lib/extended-page-mod.js
@@ -75,8 +75,12 @@ const Rules = Class({
   },
   remove(rules) {
     [].concat(rules).forEach(rule => {
-      this._map.delete(rule);
-      this.emit('remove', rule);
+      //@NOTE: Remove causes Manager to try to remove all bindings to the same url/rule
+      //across all instances, which means the same instance that removes the url/rule
+      //will be hit again causing infinite recursion. We can either avoid calling remove on the
+      //same instance or check that delete completed successfully.
+      //Opted to ensure delete is true.
+      this._map.delete(rule) && this.emit('remove', rule);
     });
   },
   emit: selfEmit,


### PR DESCRIPTION
Disabling the addon wasn't checked before, so never saw the infinite recursion problem. I also found I left in the deprecated windowIterator and created some replacement code. Lastly, I saw a few errors once in awhile with the tab being undefined in `WorkerMap`, causing it to fail, so I implemented what should be a less error prone solution.

The chain for the `WorkerMap` issue was `extended-page-mod` --> `site-configuration` --> `worker-map` (`WorkerMap.register`)

More Firefox fun for @nzack and @JasonGhent 
